### PR TITLE
PP-12343: Fix create release command

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -84,4 +84,4 @@ jobs:
           MODULE_VERSION: "${{ steps.load-module-version.outputs.MODULE_VERSION }}"
         run: |
           echo "Creating release ${MODULE_VERSION}"
-          gh release create --create-notes --latest "${MODULE_VERSION}" build/*
+          gh release create --generate-notes --latest "${MODULE_VERSION}" build/*


### PR DESCRIPTION
Fix incorrect flag to gh release create.

From the help text:
```
USAGE
  gh release create [<tag>] [<files>...]

ALIASES
  new

FLAGS
      --discussion-category string   Start a discussion in the specified category
  -d, --draft                        Save the release as a draft instead of publishing it
      --generate-notes               Automatically generate title and notes for the release
      --latest                       Mark this release as "Latest" (default [automatic based on date and version])
  -n, --notes string                 Release notes
  -F, --notes-file file              Read release notes from file (use "-" to read from standard input)
      --notes-from-tag               Automatically generate notes from annotated tag
      --notes-start-tag string       Tag to use as the starting point for generating release notes
  -p, --prerelease                   Mark the release as a prerelease
      --target branch                Target branch or full commit SHA (default [main branch])
  -t, --title string                 Release title
      --verify-tag                   Abort i
```