### PR TITLE
PP-12343: Give gh cli a token

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -82,6 +82,7 @@ jobs:
         name: Release new version
         env:
           MODULE_VERSION: "${{ steps.load-module-version.outputs.MODULE_VERSION }}"
+          GH_TOKEN: "${{ github.token }}"
         run: |
           echo "Creating release ${MODULE_VERSION}"
           gh release create --generate-notes --latest "${MODULE_VERSION}" build/*


### PR DESCRIPTION
Error from [previous run](https://github.com/alphagov/pkl-concourse-pipeline/actions/runs/8143334028/job/22254962525) of post-merge:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```