### PR TITLE
PP-12343: Fix zip url for releases tagged with just the version number

### DIFF
--- a/src/PklProject
+++ b/src/PklProject
@@ -7,7 +7,7 @@ package {
   baseUri = "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline"
   sourceCode = "https://github.com/alphagov/pkl-concourse-pipeline"
   sourceCodeUrlScheme = "\(sourceCode)/blob/\(name)@\(version)%{path}#L%{line}-L%{endLine}"
-  packageZipUrl = "\(sourceCode)/releases/download/\(name)@\(version)/\(name)@\(version).zip"
+  packageZipUrl = "\(sourceCode)/releases/download/\(version)/\(name)@\(version).zip"
   description = """
   Pkl Modules for concourse pipelines.
   


### PR DESCRIPTION
The packageZipUrl needs to exactly match the format of where the zip is. In the example I followed their release tag is `<project>@<version>`, but ours is just `<version>` so change the ZipUrl to match our actual zip paths on GitHub.

I _believe_ this should work, but if it doesn't we can also try https://github.com/alphagov/pkl-concourse-pipeline/pull/6