### PR TITLE
BAU: Ignore .idea/ and .DS_Strore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea/
+.DS_Store
 build/


### PR DESCRIPTION
We don't commit the IntelliJ IDEA project dir to git. We don't commit the macOS directory metadata file to git.

Added `.idea/` and `.DS_Store` to `.gitignore`