### PR TITLE
BAU: Make image_resource NOT required

### DIFF
--- a/src/TaskConfig.pkl
+++ b/src/TaskConfig.pkl
@@ -3,7 +3,7 @@ module concourse_pipeline.TaskConfig
 import "./Pipeline.pkl"
 
 platform: "linux"|"darwin"|"windows"
-image_resource: AnonymousResource
+image_resource: AnonymousResource?
 inputs: Listing<Input>?
 outputs: Listing<Output>?
 caches: Listing<Cache>?


### PR DESCRIPTION
The [task-config docs](https://concourse-ci.org/tasks.html#schema.task-config) says that [image_resource](https://concourse-ci.org/tasks.html#schema.task-config.image_resource) is required, and so `TaskConfig.pkl` has `image_resource` be [required](https://github.com/alphagov/pkl-concourse-pipeline/blob/b9267b7d8b20feb306ca46c7c4302f5d5926614d/src/TaskConfig.pkl#L6).

However the [task step docs](https://concourse-ci.org/task-step.html#task-step) note that specifying the [optional image](https://concourse-ci.org/task-step.html#schema.task.image) there overrides `image_resource` on `task-config` making it redundant and NOT ACTUALLY REQUIRED.

Allow `image_resource` to be optional for now.

A more sophisticated validation may allow for conforming to the concourse spec, but this is out of scope for now.