### PR TITLE
Add the IDToken var source

### DIFF
--- a/src/Pipeline.pkl
+++ b/src/Pipeline.pkl
@@ -198,6 +198,18 @@ open class SSMConfig {
   region: String
 }
 
+open class IDTokenVarSource extends VarSource {
+  type: "idtoken"
+  config: IDTokenConfig
+}
+
+open class IDTokenConfig {
+  audience: Listing<String>
+  subject_scope: "team" | "pipeline" | "instance" | "job" | String
+  expires_in: ConcourseDuration
+  algorithm: "RS256" | "ES256" | String
+}
+
 open class DummyVarSource extends VarSource {
   type: "dummy"
   config: DummyConfig

--- a/src/PklProject
+++ b/src/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 package {
   name = "pkl-concourse-pipeline"
-  version = "0.0.4"
+  version = "0.0.5"
   license = "MIT"
   baseUri = "package://pkg.pkl-lang.org/github.com/alphagov/pkl-concourse-pipeline"
   sourceCode = "https://github.com/alphagov/pkl-concourse-pipeline"


### PR DESCRIPTION
Concourse 7.14 added the [IDToken var source](https://concourse-ci.org/idtoken-credential-manager.html). This adds support for it into this module.

You can see the [IDToken var source schema](https://concourse-ci.org/vars.html#schema.idtoken_config) in the concourse docs.